### PR TITLE
Remove Redundant DOM Identifiers

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -58,13 +58,13 @@ form input[type="text"]:focus {
     @apply focus:outline-none focus:border-white focus:ring-0
 }
 
-.line-numbers {
+#line-numbers {
     @apply border border-white font-brand font-regular text-xs text-emDark-light bg-emDark-dark h-[300px] w-[54px] text-right overflow-hidden resize-none;
     border-right: none;
     border-top: none;
 }
 
-.line-numbers:focus {
+#line-numbers:focus {
     @apply focus:outline-none focus:border-white focus:ring-0;
 }
 

--- a/lib/elixir_gist_web/live/gist_form_component.ex
+++ b/lib/elixir_gist_web/live/gist_form_component.ex
@@ -37,7 +37,7 @@ defmodule ElixirGistWeb.GistFormComponent do
               </div>
             </div>
             <div id="gist-wrapper" class="flex w-full" phx-update="ignore">
-              <textarea id="line-numbers" class="line-numbers rounded-bl-md" readonly>
+              <textarea id="line-numbers" class="rounded-bl-md" readonly>
           <%= "1\n" %>
         </textarea>
               <%= textarea(@form, :markup_text,


### PR DESCRIPTION
This PR addresses a code redundancy issue where both an ID and a class with the same name `line-numbers` were being used. 
